### PR TITLE
attributes: fix (invalid) attributes, was generating a TypeError

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,4 @@
 case node['platform']
 when "ubuntu"
-  default['modules']['lp']
-  default['modules']['rtc']
+  default['modules'] = %w(lp rtc)
 end


### PR DESCRIPTION
The syntax here was bad, wouldn't compile in Chef 11.4.4 omnibus environment due to TypeError
