### PR TITLE
Ruby 1.8.7 support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ default['modules']['packages'] = value_for_platform_family(
       "default" => ["kmod"],
       ["10.04","12.04","12.10"] => ["module-init-tools"],
     },
-    "default" => ["kmod"],
+    "default" => ["kmod"]
   ),
-  "default" => [],
+  "default" => []
 )


### PR DESCRIPTION
The following two minor changes make the cookbook syntax-compatible with Ruby 1.8.7, which is an unfortunate requirement for anyone running on Amazon OpsWorks. (FWIW, this was the only such change required for the [docker cookbook](https://github.com/bflad/chef-docker) and all its dependencies.)
