### PR TITLE
Add parentheses around function arg hash in attrs.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,13 +3,13 @@ when "ubuntu"
   default['modules']['default']['modules'] = ['lp', 'rtc']
 end
 
-default['modules']['packages'] = value_for_platform_family(
-  "debian" => value_for_platform(
+default['modules']['packages'] = value_for_platform_family({
+  "debian" => value_for_platform({
     "ubuntu" => {
       "default" => ["kmod"],
       ["10.04","12.04","12.10"] => ["module-init-tools"],
     },
     "default" => ["kmod"],
-  ),
+  }),
   "default" => [],
-)
+})


### PR DESCRIPTION
This should now work when chef is running on older version of ruby :)
