### PR TITLE
Workaround for non-ubuntu platforms.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,4 @@
 #
 
 include_recipe 'modules::config'
-include_recipe 'modules::install_attributes'
+include_recipe 'modules::install_attributes' if node['platform'] == 'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,4 +18,4 @@
 #
 
 include_recipe 'modules::config'
-include_recipe 'modules::install_attributes' if node['platform'] == 'ubuntu'
+include_recipe 'modules::install_attributes'

--- a/recipes/install_attributes.rb
+++ b/recipes/install_attributes.rb
@@ -19,6 +19,8 @@
 
 # TODO: do init script.
 
+return unless supported?
+
 file '/etc/modules-load.d/chef-attibutes.conf' do
   action :delete
 end


### PR DESCRIPTION
Hi!

I use Debian 7 and I guess, the 'install_attribute' recipe works only with ubuntu. Therefore, I've made a tiny workaround to skip this recipe with other platforms.
